### PR TITLE
fixed code block display & hashtable typo

### DIFF
--- a/userinterfaces/dashboards/components/inputs/button.md
+++ b/userinterfaces/dashboards/components/inputs/button.md
@@ -30,7 +30,9 @@ New-UDButton -Variant 'outlined' -Text 'Default'
 
 You can control the pixel size of a button based on pixel size by using the Style parameter
 
-'''text New-UDButton -Id "Submit" -Text "Submit" -Style @{ Width = "150px" Height = "100px" }
+```text
+New-UDButton -Id "Submit" -Text "Submit" -Style @{ Width = "150px"; Height = "100px" }
+```
 
 ## Buttons with icons and label
 


### PR DESCRIPTION
I noticed a typo in the docs for `UD-Button` while building a dashboard today. The code block wasn't displaying properly, and the `-Style` hashtable values needed a separator.