### PR TITLE
Update and rename whats-new-in-v3.md to whats-new-in-v5.md

### DIFF
--- a/whats-new-in-v5.md
+++ b/whats-new-in-v5.md
@@ -16,7 +16,7 @@ Blazor apps are simplified user interfaces that take advantage of PSBlazor to al
 
 ## PostgreSQL Support
 
-PostgreSQL is not supported as a persistence store.&#x20;
+PostgreSQL is now supported as a persistence store.&#x20;
 
 ## Updated Runtimes
 


### PR DESCRIPTION
clarify that PostgreSQL is now in fact supported as a backend