### PR TITLE
Update endpoints.md

### DIFF
--- a/api/endpoints.md
+++ b/api/endpoints.md
@@ -4,7 +4,7 @@ description: Endpoint configuration for Universal APIs.
 
 # Endpoints
 
-Endpoints are defined by their URI and HTTP method. Calls made to the Universal server that match the API endpoint and method that you define will execute the API endpoint script.
+Endpoints are defined by their URI and HTTP method. Calls made to the Universal server that match your defined API endpoint and method execute the API endpoint script.
 
 ```powershell
 New-PSUEndpoint -Url '/endpoint' -Method 'GET' -Endpoint {
@@ -12,24 +12,24 @@ New-PSUEndpoint -Url '/endpoint' -Method 'GET' -Endpoint {
 }
 ```
 
-To invoke the above method, you could use `Invoke-RestMethod`.
+To invoke the above method, you can use `Invoke-RestMethod`.
 
 ```powershell
 Invoke-RestMethod http://localhost:5000/endpoint
 ```
 
-When defining endpoints in the management API, you can skip the `New-PSUEndpoint` call as it will be defined by the admin console.
+When defining endpoints in the management API, you can skip the `New-PSUEndpoint` call, as the admin console defines it.
 
 ![API Properties](<../.gitbook/assets/image (442).png>)
 
-The only contents that you need to provide in the editor will be the script you wish to call.
+The only contents that you need to provide in the editor are the script you wish to call.
 
 ![API Content](<../.gitbook/assets/image (550).png>)
 
 
 
 {% hint style="warning" %}
-Be aware that you should avoid using endpoint URLs that match with internal PowerShell Universal Management API URLs as this will cause unexpected behavior. You can reference the [OpenAPI documentation](openapi.md#management-api-documentation) for the [Management API](../config/management-api.md) to verify this is not the case.&#x20;
+Avoid using endpoint URLs that match internal PowerShell Universal Management API URLs, as this causes unexpected behavior. You can reference the [OpenAPI documentation](openapi.md#management-api-documentation) for the [Management API](../config/management-api.md) to verify that none of the URLs match.&#x20;
 {% endhint %}
 
 ## HTTP Methods
@@ -58,7 +58,7 @@ New-PSUEndpoint -Url '/user/:id' -Method 'GET' -Endpoint {
 }
 ```
 
-To call this API and specify the ID, you would do the following.
+To call this API and specify the ID, do the following:
 
 ```powershell
 Invoke-RestMethod http://localhost:5000/user/123
@@ -66,7 +66,7 @@ Invoke-RestMethod http://localhost:5000/user/123
 
 ## Query String Parameters
 
-Query string parameters are automatically passed into endpoints as variables that you can then access. For example, if you had an endpoint that expected an `$Id` variable, it could be provided via the query string.
+Query string parameters are automatically passed into endpoints as variables that you can then access. For example, if you have an endpoint that expects an `$Id` variable, you can provide it in the query string.
 
 ```powershell
 New-PSUEndpoint -Url '/user' -Method 'GET' -Endpoint {
@@ -84,7 +84,7 @@ Invoke-RestMethod http://localhost:5000/user?Id=123
 
 When accepting input via Query String parameters you may be vulnerable to [CWE-914: Improper Control of Dynamically-Identified Variables](https://cwe.mitre.org/data/definitions/914.html). Consider using a `param` block to ensure that only valid parameters are provided to the endpoint.
 
-Below is an example of CWE-914. A `$IsChallengePassed` query string parameter could be included to bypass the challenge.
+Below is an example of CWE-914. Include a `$IsChallengePassed` query string parameter to bypass the challenge.
 
 ```powershell
 New-PSUEndpoint -Url "/api/v1.0/CWE914Test" -Description "Vulnerable to CWE-914" -Endpoint {
@@ -119,7 +119,7 @@ New-PSUEndpoint -Url "/api/v1.0/CWE914Test" -Description "Not Vulnerable to CWE-
 
 ## Headers
 
-Request headers are available in APIs using the `$Headers` variable. The variable is a hashtable. To access a header, use the following syntax.
+Request headers are available in APIs using the `$Headers` variable. The variable is a hashtable. To access a header, use the following syntax:
 
 ```powershell
 $Headers['Content-Type']
@@ -127,13 +127,13 @@ $Headers['Content-Type']
 
 ## Cookies
 
-Request cookies are availablein APIs using the `$Cookies` variable. The variable is a hashtable. To access a cookie, use the following syntax.
+Request cookies are available in APIs using the `$Cookies` variable. The variable is a hashtable. To access a cookie, use the following syntax:
 
 ```powershell
 $Cookies['Request-Cookie']
 ```
 
-Request cookies can be sent back using the `New-PSUApiResponse` cmdlet. Use the `-Cookies` parameter with a supplied hashtable.
+Send back request cookies with the `New-PSUApiResponse` cmdlet. Use the `-Cookies` parameter with a supplied hashtable.
 
 ```powershell
 New-PSUApiResponse -StatusCode 200 -Cookies @{
@@ -152,7 +152,7 @@ New-PSUEndpoint -Url '/user' -Method Post -Endpoint {
 }
 ```
 
-To call the above endpoint, you would have to specify the body of `Invoke-RestMethod`.
+To call the above endpoint, specify the body of `Invoke-RestMethod`.
 
 ```powershell
 Invoke-RestMethod http://localhost:5000/user -Method Post -Body "{'username': 'adam'}"
@@ -160,13 +160,13 @@ Invoke-RestMethod http://localhost:5000/user -Method Post -Body "{'username': 'a
 
 ## Live Log
 
-You can view the live log information for any endpoint by clicking the log tab. Live logs include URL, HTTP method, source IP address, PowerShell streams, status code, return Content Type and HTTP content length.
+You can view the live log information for any endpoint by clicking the log tab. Live logs include URL, HTTP method, source IP address, PowerShell streams, status code, return Content Type, and HTTP content length.
 
 ![](<../.gitbook/assets/image (407).png>)
 
 ## Form Data
 
-You can pass data to an endpoint as form data. Form data will be passed into your endpoint as parameters.
+You can pass data to an endpoint as form data. Form data will pass into your endpoint as parameters.
 
 ```powershell
 New-PSUEndpoint -Url '/user' -Method Post -Endpoint {
@@ -220,9 +220,9 @@ New-PSUEndpoint -Url '/user/:name' -Endpoint {
 }
 ```
 
-When using the `param` block with route parameters, like the above example, you must include the route variable in your parameter. If it is not specified, you will not have access to that value.&#x20;
+When using the `param` block with route parameters like the above example, you must include the route variable in your parameter. If it is not specified, you will not have access to that value.&#x20;
 
-For example, the following `$Name` variable will always be `$null`. The endpoint will always return false.&#x20;
+For example, the following `$Name` variable is always `$null`. The endpoint always returns false.&#x20;
 
 ```powershell
 New-PSUEndpoint -Url '/user/:name' -Endpoint {
@@ -234,7 +234,7 @@ New-PSUEndpoint -Url '/user/:name' -Endpoint {
 
 ## Returning Data
 
-Data returned from endpoints will be assumed to be JSON data. If you return an object from the endpoint script block, it will be automatically serialized to JSON. If you want to return another type of data, you can return a string formatted however you chose.
+Data returned from endpoints is assumed to be JSON data. If you return an object from the endpoint script block, it is automatically serialized to JSON. If you want to return another type of data, you can return a string formatted however you chose.
 
 ## Processing Files
 
@@ -260,7 +260,7 @@ Content           : [137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,2,17,0,0,
 `The multipart/form-data`content type is not supported for uploading files to APIs.
 {% endhint %}
 
-You could also save the file into a directory.
+You can also save the file into a directory.
 
 ```powershell
 New-PSUEndpoint -Url '/file' -Method Post -Endpoint {
@@ -289,7 +289,7 @@ New-PSUEndpoint -Url '/file' -Method Get -Endpoint {
 }
 ```
 
-You can also return custom body data by using the `-Body` parameter of `New-PSUApiResponse`.
+You can also return custom body data with the `-Body` parameter of `New-PSUApiResponse`.
 
 ```powershell
 New-PSUEndpoint -Url '/file' -Method Get -Endpoint {
@@ -297,7 +297,7 @@ New-PSUEndpoint -Url '/file' -Method Get -Endpoint {
 }
 ```
 
-Invoking the REST method will return the custom error code.
+Invoking the REST method returns the custom error code.
 
 ```powershell
 PS C:\Users\adamr\Desktop> invoke-restmethod http://localhost:8080/file
@@ -305,7 +305,7 @@ PS C:\Users\adamr\Desktop> invoke-restmethod http://localhost:8080/file
 Invoke-RestMethod: Not what you're looking for.
 ```
 
-You can control the content type of the data that is returned by using the `-ContentType` parameter.
+You can control the content type of the returned data with the `-ContentType` parameter.
 
 ```powershell
 New-PSUEndpoint -Url '/file' -Method Get -Endpoint {
@@ -319,7 +319,7 @@ New-PSUEndpoint -Url '/file' -Method Get -Endpoint {
 
 Persistent runspaces allow you to maintain runspace state between API calls. This is important for users that perform some sort of initialization within their endpoints that they do not want to execute on subsequent API calls.
 
-By default, runspaces will be reset after each execution. This will cause variables, modules and functions defined during the execution of the API to be removed.
+By default, runspaces are reset after each execution. This removes variables, modules and functions defined during the execution of the API.
 
 To enable persistent runspaces, you will need to configure an [environment ](../config/environments.md)for your API. Set the `-PersistentRunspace` parameter to enable this feature. This is configured in the `environments.ps1` script.
 
@@ -339,9 +339,9 @@ By default, endpoints will not time out. To set a timeout for your endpoints, yo
 
 ## External Endpoint Content
 
-You can define the path to an external endpoint content file by using the `-Path` parameter of `New-PSUEndpoint`. The path is relative to the `.universal` directory in Repository.
+You can define the path to an external endpoint content file with the `-Path` parameter of `New-PSUEndpoint`. The path is relative to the `.universal` directory in Repository.
 
-The content of the `endpoints.ps1` file is then this.
+The content of the `endpoints.ps1` file is then this:
 
 ```powershell
 New-PSUEndpoint -Url "/path" -Path "endpoint-path.ps1"
@@ -351,7 +351,7 @@ New-PSUEndpoint -Url "/path" -Path "endpoint-path.ps1"
 
 C# APIs are enabled as a [plugin](../platform/plugins.md#c-api-environment).
 
-There is no UI for creating a C# API and you will need to do so using configuration files. First, you will need to create a `.cs` file that will run your API.
+There is no UI for creating a C# API, so you need to do so using configuration files. First, create a `.cs` file that runs your API.
 
 You will have access to a `request` parameter that includes all the data about the API request.
 
@@ -373,7 +373,7 @@ public class ApiRequest
 }
 ```
 
-You will also have access to a `ServiceProvider` property that will allow you to access services within PowerShell Universal. These are currently not well documented but below is an example of restarting a dashboard.
+You will also have access to a `ServiceProvider` property that allows you to access services within PowerShell Universal. These are not currently well-documented, but below is an example of restarting a dashboard.
 
 ```csharp
 var dm = ServiceProvider.GetService(typeof(IDashboardManager));
@@ -381,7 +381,7 @@ var dashboard = dm.GetDashboard(1);
 dm.Restart(dashboard);
 ```
 
-Some other useful services may include:
+Some other useful services include:
 
 * IDatabase
 * IApiService
@@ -401,8 +401,7 @@ Once you have defined your C# endpoint file, you can add it by editing `endpoint
 ```powershell
 New-PSUEndpoint -Url /csharp -Path endpoint.cs -Environment 'C#'
 ```
-
-C# endpoints are compiled and run directly in the PowerShell Universal service.
+The PowerShell Universal service automatically compiles and runs C# endpoints. 
 
 ## API
 


### PR DESCRIPTION
Minor grammatical changes for concision. Only 1 typo in the whole thing! One word I wasn't sure about is where you have byte\[] in the documentation, so your users see "[...] even specify the byte[] data for the content to be returned." I wasn't sure if that's the intended output. (Didn't change it.)