### PR TITLE
Update README.md

### DIFF
--- a/automation/scripts/README.md
+++ b/automation/scripts/README.md
@@ -4,15 +4,15 @@ description: PowerShell scripts to execute within PowerShell Universal.
 
 # Scripts
 
-PowerShell scripts can be created within PowerShell Universal to execute manually, on a scheudle or when events happen within the platform. They are stored on disk and also persisted to a local or remote Git repository.
+You can create PowerShell scripts within PowerShell Universal to execute manually, on a schedule, or when events happen within the platform. They are stored on disk and they persist to a local or remote Git repository.
 
 {% hint style="info" %}
-Script properties are stored in the `scripts.ps1` configuration file.
+The `scripts.ps1` configuration file stores the Script properties.
 {% endhint %}
 
 ## Add a New Script
 
-To add a new script, you can click the New Script button within the Automation / Scripts page. There are various settings you can provide for the script.
+To add a new script, click the New Script button within the Automation / Scripts page. There are various settings you can provide for the script.
 
 ![](<../../.gitbook/assets/image (230).png>)
 
@@ -20,7 +20,7 @@ To add a new script, you can click the New Script button within the Automation /
 
 ### **Name**
 
-Name of the script as shown in Universal Automation. This will also be the name used to persist the script to disk. This setting needs to be unique within the current folder.
+This is the name of the script as shown in Universal Automation. This is also the name used to persist the script to disk. The name needs to be unique within the current folder.
 
 ### Module and Command
 
@@ -28,37 +28,37 @@ See [Modules and Commands](./#modules-and-commands) below.
 
 ### **Description**
 
-A description of the script. This is shown in various places within the UA UI and also returned by the Universal cmdlets.
+This description of the script shows in various places within the UA UI and is returned by the Universal cmdlets.
 
 ### **Disable Manual Invocation**
 
-Prevents a script from being run manually. This is enforced in the UI as well as the web server and cmdlets.
+This prevents a script from running manually. This is enforced in the UI as well as the web server and cmdlets.
 
 ### **Max Job History**
 
-Defaults to 100. It defines the amount of jobs that are stored when running this script. Jobs are also cleaned up based on the server-wide job retention duration setting from within the Settings / General page.
+The max job history defines the amount of jobs stored when running this script. It defaults to 100. Jobs are also cleaned up based on the server-wide job retention duration setting from the Settings / General page.
 
 ### **Error Action**
 
-Changes how the script reacts when there is an error within the script. By default, terminating and non-terminating errors are ignored and the script will always be successful. You can change this setting to stop to cause scripts to fail immediately when an error is encountered.
+The error action changes how the script reacts when it has an error. By default, terminating and non-terminating errors are ignored and the script always succeeds. You can change this setting to stop to cause scripts to fail immediately when an error is encountered.
 
-If you wish to write errors directly to the error pane without causing changes in how the script is handled (for example in an exception handler), you can use `Write-PSUError` to output the error record and it will appear in the error tab of the job.
+If you wish to write errors directly to the error pane without causing changes in how the script is handled (for example in an exception handler), use `Write-PSUError` to output the error record and it appears in the job's error tab.
 
 ### **Environment**
 
-Allows you to define the required PowerShell environment for the script. By default, it uses the server-wide default PowerShell environment. PowerShell environments are automatically located the first the Universal Server starts up or read from the `environments.ps1` file. You can also add Environment on the Settings / Environments page.
+This allows you to define the required PowerShell environment for the script. By default, it uses the server-wide default PowerShell environment. PowerShell environments are automatically located the first time the Universal Server starts up or read from the `environments.ps1` file. You can also add Environment on the Settings / Environments page.
 
 ### **Timeout**
 
-The number of minutes before the script will timeout. The default value of 0 means the script will run forever. Once a script reaches it's time out, it will be cancelled.
+The number of minutes before the script times out. The default value of 0 means the script will run forever. Once a script reaches its timeout, it is canceled.
 
 ### Discard Pipeline
 
-When checked, this will disable the storage of pipeline output. This will greatly reduce the CPU and storage overhead of jobs. The script will still write to the information, warning, and error streams.
+When checked, this disables pipeline output storage. This greatly reduces jobs' CPU and storage overhead, but the script still writes to the information, warning, and error streams.
 
 ### **Concurrent Jobs**
 
-Defines the maximum concurrent jobs the script can be run. Defaults to 100.
+Defines the maximum concurrent jobs with which the script can be run. It defaults to 100.
 
 ```powershell
 New-PSUScript -Name Script.ps1 -Path Script.Ps1 -ConcurrentJobs 1
@@ -66,19 +66,19 @@ New-PSUScript -Name Script.ps1 -Path Script.Ps1 -ConcurrentJobs 1
 
 ## Running a Script
 
-You can run a script in the UI by click the Run button the Automation / Scripts page or by clicking View and then Run. In each case, you will be presented with the Run Dialog that allows you to select various settings for the job.
+You can run a script in the UI from the Automation / Scripts page by clicking Run or by clicking View and then Run. In each case, the Run Dialog appears, allowing you to select various settings for the job.
 
 ![](<../../.gitbook/assets/image (225).png>)
 
 ### Running a Script With Parameters
 
 {% hint style="info" %}
-Learn more about [parameters here](parameters.md).
+Learn more about parameters [here](parameters.md).
 {% endhint %}
 
 PowerShell Universal automatically determines the parameters as defined within your scripts. It takes advantage of static code analysis to determine the type, default values and some validation that is then presented within the UI.
 
-For example, you may have a script with the following parameters.
+For example, you may have a script with the following parameters:
 
 ```powershell
 param(
@@ -90,7 +90,7 @@ param(
 )
 ```
 
-The result is a set of input options that are based on the types of parameters.
+The result is a set of input options based on the types of parameters.
 
 ![](<../../.gitbook/assets/image (420).png>)
 
@@ -102,25 +102,25 @@ The integrated [environment](../../config/environments.md) does not support runn
 
 You can run scripts as another user by configuring [secret variables](../../platform/variables.md#creating-a-secret-variable). PowerShell Universal uses the Microsoft Secret Management module to integrate with secret providers. See variables for more information on secrets.
 
-To run as another user, simply add or import a PSCredential variable. From there, you can select the credential from within the run dialog.
+To run as another user, simply add or import a PSCredential variable. From there, you can select the credential within the run dialog.
 
 ![](<../../.gitbook/assets/image (89).png>)
 
 ### Running a Script on Another Computer
 
-You can use the Computer drop down to select other machines to run a script on. The default value is to run on any computer that is available.
+You can use the Computer dropdown to select other machines on which to run a script. The default value is to run on any available computer.
 
 ### Running a Script on All Computers
 
-You can run a script on all computers by selecting the All Computers option from the Computer drop down.
+You can run a script on all computers by selecting the All Computers option from the Computer dropdown.
 
 ## Remoting
 
-Note that you can use PowerShell remoting by taking advantage of `Invoke-Command` . We do not support the use of `Enter-PSSession` or `Import-PSSession`.
+You can use PowerShell remoting by taking advantage of `Invoke-Command` . We do not support the use of `Enter-PSSession` or `Import-PSSession`.
 
 ## Comment-Based Help
 
-You can use comment-based to define the description, a synopsis, parameter based help, and links for your scripts. These will be displayed within the PowerShell Universal UI.
+You can use comment-based help to define the description, a synopsis, parameter-based help, and links for your scripts. These will be displayed within the PowerShell Universal UI.
 
 ```powershell
 <#
@@ -144,13 +144,13 @@ param($HostName)
 Test-NetConnection $HostName
 ```
 
-This above will yield the following user interface. The synopsis will be shown as the short description and a longer description can be shown in the description section. Links will appear under the description.
+The above yields the following user interface. The synopsis displays as the short description, and a longer description displays in the description section. Links appear under the description.
 
 ![](<../../.gitbook/assets/image (431).png>)
 
 ## Modules and Commands
 
-Commands and cmdlets found in modules can be used at the target for scripts rather than authoring the script directly.&#x20;
+Commands and cmdlets found in modules can be used as the target for scripts rather than authoring the script directly.&#x20;
 
 Let's assume that we have a module called `PSUModule` that contains the following function.
 
@@ -167,7 +167,7 @@ It's possible to expose this function as a script by using the following syntax 
 New-PSUScript -Module 'PSUModule' -Command 'Show-HelloWorld'
 ```
 
-The function will be surfaced just as other scripts within the admin console. Parameters, help text and other PSU features will work the same as with scripts.
+The function surfaces just like other scripts within the admin console. Parameters, help text and other PSU features work the same as with scripts.
 
 <figure><img src="../../.gitbook/assets/image (578).png" alt=""><figcaption><p>Parameter for a function<br></p></figcaption></figure>
 


### PR DESCRIPTION
Some changes for concision. A few changes for things I thought were typos (like "at the target" I changed to "as the target"), but I wasn't totally sure. for instance, the last couple sections:

"cmdlets found in modules can be used at the target for scripts" I changed to "used *as* target"

"just as" I changed to "just like" to avoid confusion with "just as" when it means "at the same time as".