### PR TITLE
Update components-link in building-dashboards.md

### DIFF
--- a/apps/building-dashboards.md
+++ b/apps/building-dashboards.md
@@ -68,7 +68,7 @@ New-UDPage -Content {
 }
 ```
 
-Learn more about [components here](building-dashboards.md#components).
+Learn more about [components here](components).
 
 ## Pages
 


### PR DESCRIPTION
The current link references the anchor of the paragraph the link is in. A link to https://docs.powershelluniversal.com/apps/components would be a better fit.