### PR TITLE
Add details about the ExternalGit property in appsettings.json

### DIFF
--- a/config/git.md
+++ b/config/git.md
@@ -130,6 +130,7 @@ Manual mode can be set in the git settings within the admin console or within `a
   "GitInitializeBehavior": "",
   "GitSyncInterval": "1",
   "ConfigurationScript": "",
+  "ExternalGitClient": false
   "Mode": "Manual" // Or Automatic
 },
 ```

--- a/config/settings.md
+++ b/config/settings.md
@@ -153,6 +153,7 @@ Configures the hosts that are allowed to make cross-origin resource sharing requ
   "GitPassword": "", 
   "GitBranch": "",
   "ConfigurationScript": "",
+  "ExternalGitClient": false,
   "Mode": "automatic"
 },
 ```
@@ -166,6 +167,7 @@ Configures the hosts that are allowed to make cross-origin resource sharing requ
 | GitUserName         | Git user name used to sync to the GitRemote. When using a PAT, this can be any value.                                              |
 | GitPassword         | The Git user password or personal access token used to sync to the GitRemote.                                                      |
 | ConfigurationScript | Location of a custom configuration script to load. You can return objects like scripts, dashboards and endpoints from this script. |
+| ExternalGitClient   | When set to true the Operating Systems Git client will be used instead of the inbuilt library client                               |
 | Mode                | Sets the git mode. It can be either manual or automatic. Defaults to manual.                                                       |
 
 ### **API**


### PR DESCRIPTION
Added this after Adam shared the deets on the forum and we now use this in production

One other item I debated adding is that we use a Windows Server and the PAT key can be stored by the Git Credential Manager in the windows credential store of the service account using this  methodology. 

I wasn't sure if it was worth adding those steps to the doc or not, but if it is let me know and I can try to make something useful