### PR TITLE
Change example command for Stop-PSUApp

### DIFF
--- a/cmdlets/Stop-PSUApp.txt
+++ b/cmdlets/Stop-PSUApp.txt
@@ -120,7 +120,7 @@ NOTES
     
     -------------------------- Example 1 --------------------------
     
-    PS C:\> Get-PSUApp -Name 'MyApp' | Stop-PSUApp
+    PS C:\> Stop-PSUApp -Name 'MyApp'
     
     Stops the 'MyApp' app in PowerShell Universal.
     


### PR DESCRIPTION
Updated example usage for Stop-PSUApp cmdlet.

The "Get-PSUApp -Name .. | Stop-PSUApp" doesnt work anymore